### PR TITLE
Fix missing string assignment in BaseException

### DIFF
--- a/D3DPracticing/BaseException.cpp
+++ b/D3DPracticing/BaseException.cpp
@@ -7,10 +7,11 @@ BaseException::BaseException(int line, std::string_view file) : line(line), file
 
 char const* BaseException::what() const
 {
-	std::ostringstream oss;
-	oss << GetType() << std::endl
-		<< GetOriginString();
-	return whatBuffer.c_str();
+        std::ostringstream oss;
+        oss << GetType() << std::endl
+                << GetOriginString();
+        whatBuffer = oss.str();
+        return whatBuffer.c_str();
 }
 
 const char* BaseException::GetType() const


### PR DESCRIPTION
## Summary
- fix BaseException::what() not populating error message buffer

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f045e93a08321b8a8c014ed46d7d5