### PR TITLE
Destroy window on construction failure

### DIFF
--- a/D3DPracticing/Window.cpp
+++ b/D3DPracticing/Window.cpp
@@ -201,9 +201,15 @@ Window::Window(int width, int height, std::string_view name)
 		}
 		ShowWindow(hWnd, SW_SHOWDEFAULT);
 		pGfx = std::make_unique<Graphics>(hWnd);
+	}
+	catch (...)
+	{
+		// Workaround to avoid crashing during wndProc events
+		if (hWnd != nullptr)
+		{
+			SetWindowLongPtr(hWnd, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(&DefWindowProc));
+			DestroyWindow(hWnd);
 		}
-	catch (...) { // Workaround to avoid crashing during wndProc events
-		SetWindowLongPtr(hWnd, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(&DefWindowProc));
 		throw;
 	}
 }


### PR DESCRIPTION
## Summary
- Clean up window handle if the Window constructor throws
- Align catch block formatting with project style

## Testing
- `g++ -c Window.cpp -o /tmp/window.o` *(fails: sdkddkver.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3459e04c8321ac2b69d10c15ad1e