### PR TITLE
Wrap graphics macros in do-while blocks

### DIFF
--- a/D3DPracticing/Graphics.cpp
+++ b/D3DPracticing/Graphics.cpp
@@ -185,7 +185,7 @@ void Graphics::EndFrame()
 	{
 		if (hr == DXGI_ERROR_DEVICE_REMOVED)
 		{
-			throw GFX_DEVICE_REMOVED_EXCEPT(pDevice->GetDeviceRemovedReason());
+			GFX_DEVICE_REMOVED_EXCEPT(pDevice->GetDeviceRemovedReason());
 		}
 		else
 		{

--- a/D3DPracticing/GraphicsMacros.h
+++ b/D3DPracticing/GraphicsMacros.h
@@ -1,18 +1,18 @@
 #pragma once
 
 #define GFX_EXCEPT_NO_INFO(hr) Graphics::HrException(__LINE__, __FILE__, (hr))
-#define GFX_THROW_NO_INFO(hrCall) if (FAILED(hr = (hrCall))) throw GFX_EXCEPT_NO_INFO(hr)
+#define GFX_THROW_NO_INFO(hrCall) do { if (FAILED(hr = (hrCall))) throw GFX_EXCEPT_NO_INFO(hr); } while(false)
 
 #ifndef NDEBUG
 #define GFX_EXCEPT(hr) Graphics::HrException(__LINE__, __FILE__, (hr), infoManager.GetMessages())
-#define GFX_THROW_INFO(hrCall) infoManager.Set(); if (FAILED(hr = (hrCall))) throw GFX_EXCEPT(hr)
-#define GFX_DEVICE_REMOVED_EXCEPT(hr) Graphics::DeviceRemovedException( __LINE__, __FILE__, (hr), infoManager.GetMessages())
-#define GFX_THROW_INFO_ONLY(call) infoManager.Set(); (call); auto messages = infoManager.GetMessages(); if (!messages.empty()) throw Graphics::InfoException(__LINE__, __FILE__, messages)
+#define GFX_THROW_INFO(hrCall) do { infoManager.Set(); if (FAILED(hr = (hrCall))) throw GFX_EXCEPT(hr); } while(false)
+#define GFX_DEVICE_REMOVED_EXCEPT(hr) do { throw Graphics::DeviceRemovedException( __LINE__, __FILE__, (hr), infoManager.GetMessages()); } while(false)
+#define GFX_THROW_INFO_ONLY(call) do { infoManager.Set(); (call); auto messages = infoManager.GetMessages(); if (!messages.empty()) throw Graphics::InfoException(__LINE__, __FILE__, messages); } while(false)
 #else
 #define GFX_EXCEPT(hr) GFX_EXCEPT_NO_INFO(hr)
 #define GFX_THROW_INFO(hrCall) GFX_THROW_NO_INFO(hrCall)
-#define GFX_DEVICE_REMOVED_EXCEPT(hr) Graphics::DeviceRemovedException( __LINE__,__FILE__,(hr) )
-#define GFX_THROW_INFO_ONLY(call) (call);
+#define GFX_DEVICE_REMOVED_EXCEPT(hr) do { throw Graphics::DeviceRemovedException( __LINE__,__FILE__,(hr) ); } while(false)
+#define GFX_THROW_INFO_ONLY(call) do { (call); } while(false)
 #endif
 
 #ifdef NDEBUG


### PR DESCRIPTION
## Summary
- Encapsulate graphics helper macros in `do { ... } while(false)` to allow safe use within control statements
- Adjust device-removed exception macro and its call site to the new statement-style macros
- Ensure `GraphicsMacros.h` terminates with a trailing newline for consistent formatting

## Testing
- `g++ -std=c++17 ../macro_test.cpp -o ../macro_test`
- `../macro_test`


------
https://chatgpt.com/codex/tasks/task_e_68bc378bfa348321b8ce6058cb6ec107